### PR TITLE
fixed bug when POST by quick_form(form)

### DIFF
--- a/flask_material/templates/material/wtf.html
+++ b/flask_material/templates/material/wtf.html
@@ -128,7 +128,7 @@ the necessary fix for required=False attributes, but will also not set the requi
 
 {# valid form types are "basic", "inline" and "horizontal" #}
 {% macro quick_form(form,
-                    action=".",
+                    action="",
                     method="post",
                     extra_classes=None,
                     role="form",


### PR DESCRIPTION
change the default parameters of action, if it's ".", when give a POST request, it's default URL is "/", it's not we want URL.